### PR TITLE
Corrected working directory

### DIFF
--- a/setup-tls
+++ b/setup-tls
@@ -35,7 +35,7 @@ function statusCheck(){
 }
 
 pause 0 'Set up a working space.  We will use the directory docker-ca in the home directory.'
-WORKING="docker-certs"
+WORKING="docker-ca"
 mkdir -v ~/$WORKING && cd ~/$WORKING && pwd
 if test $(basename $(pwd)) != "$WORKING"
 then


### PR DESCRIPTION
The working directory was set to 'docker-certs' when the comment states 'docker-ca' and all the training materials also refer to the directory as 'docker-ca'.  Changed to 'docker-ca' to eliminate confusion.